### PR TITLE
package renames and heirarchy changes

### DIFF
--- a/nbproject/private/private.properties
+++ b/nbproject/private/private.properties
@@ -1,2 +1,2 @@
 compile.on.save=true
-user.properties.file=C:\\Users\\Adam Young\\AppData\\Roaming\\NetBeans\\8.2\\build.properties
+user.properties.file=C:\\Users\\Scott\\AppData\\Roaming\\NetBeans\\8.0.2\\build.properties

--- a/src/Weiss.java
+++ b/src/Weiss.java
@@ -14,13 +14,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import weiss.MetaAgent.Agent;
-import weiss.MetaAgent.Portal;
-import weiss.MetaAgent.MetaAgent;
-import Weiss.Manager.NodeMonitor;
-import Weiss.Manager.WeissManager;
+import weiss.core.agent.Agent;
+import weiss.core.agent.Portal;
+import weiss.core.agent.MetaAgent;
+import weiss.manager.NodeMonitor;
+import weiss.manager.WeissManager;
 import java.util.logging.*;
-import weiss.Message.*;
 
 /*
  * To change this license header, choose License Headers in Project Properties.

--- a/src/weiss/core/agent/Agent.java
+++ b/src/weiss/core/agent/Agent.java
@@ -14,12 +14,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package weiss.MetaAgent;
+package weiss.core.agent;
 
 
-import weiss.Message.Message;
-import weiss.Message.SysMessage;
-import weiss.Message.UserMessage;
+import weiss.core.message.Message;
+import weiss.core.message.SysMessage;
+import weiss.core.message.UserMessage;
 
 /**
  *

--- a/src/weiss/core/agent/MetaAgent.java
+++ b/src/weiss/core/agent/MetaAgent.java
@@ -14,14 +14,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package weiss.MetaAgent;
+package weiss.core.agent;
 
-import Weiss.Manager.NodeMonitor;
+import weiss.core.message.Message;
+import weiss.core.message.RouterMessage;
+import weiss.core.message.UserMessage;
+import weiss.core.message.ReplyMessage;
+import weiss.core.message.SysMessage;
+import weiss.manager.NodeMonitor;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.ImageIcon;
-import weiss.Message.*;
 
 /**
  * An abstract class detailing the construction of a MetaAgent object, to be implemented
@@ -44,7 +48,7 @@ public abstract class MetaAgent extends WeissBase implements Runnable, Monitorab
     
     /**
      * Constructor to initialise a MetaAgetn object.
-     * @param name {@link weiss.MetaAgent.Portal Portal} belonging to MetaAgent.
+     * @param name {@link weiss.core.agent.Portal Portal} belonging to MetaAgent.
      * @param superAgent Scope of the MetaAgent.
      * @param image
      */
@@ -60,7 +64,7 @@ public abstract class MetaAgent extends WeissBase implements Runnable, Monitorab
     /**
      * Constructor to initialise a MetaAgent object, and setting the scope.
      * @param name Name of MetaAgent.
-     * @param superAgent {@link weiss.MetaAgent.Portal Portal} belonging to MetaAgent.
+     * @param superAgent {@link weiss.core.agent.Portal Portal} belonging to MetaAgent.
      * @param scope Scope of the MetaAgent.
      */
     public MetaAgent(String name, MetaAgent superAgent, int scope)
@@ -85,8 +89,8 @@ public abstract class MetaAgent extends WeissBase implements Runnable, Monitorab
         return name;
     }
     /**
-     * Getter for {@link weiss.MetaAgent.Portal Portal} object.
-     * @return {@link weiss.MetaAgent.Portal Portal} pointer.
+     * Getter for {@link weiss.core.agent.Portal Portal} object.
+     * @return {@link weiss.core.agent.Portal Portal} pointer.
      */
     public MetaAgent getSuperAgent()
     {
@@ -126,8 +130,8 @@ public abstract class MetaAgent extends WeissBase implements Runnable, Monitorab
     }
     
     /**
-     * Setter for {@link weiss.MetaAgent.Portal Portal} object.
-     * @param superAgent {@link weiss.MetaAgent.Portal Portal} object.
+     * Setter for {@link weiss.core.agent.Portal Portal} object.
+     * @param superAgent {@link weiss.core.agent.Portal Portal} object.
      */
     public final void setSuperAgent(MetaAgent superAgent)
     {   

--- a/src/weiss/core/agent/Monitorable.java
+++ b/src/weiss/core/agent/Monitorable.java
@@ -14,9 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package weiss.MetaAgent;
+package weiss.core.agent;
 
-import Weiss.Manager.NodeMonitor;
+import weiss.manager.NodeMonitor;
 
 /**
  *

--- a/src/weiss/core/agent/Portal.java
+++ b/src/weiss/core/agent/Portal.java
@@ -14,26 +14,28 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package weiss.MetaAgent;
+package weiss.core.agent;
 
+import weiss.core.message.Message;
+import weiss.core.message.UserMessage;
+import weiss.core.message.SysMessage;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import weiss.Message.*;
 
 /**
  * * Class used for handling messages from both
- * {@link weiss.MetaAgent.MetaAgent MetaAgent} classes and
- * {@link weiss.MetaAgent.Router Router} classes, and routing them to the correct
- * destination. The class implements {@link weiss.MetaAgent.MetaAgent MetaAgent},
+ * {@link weiss.core.agent.MetaAgent MetaAgent} classes and
+ * {@link weiss.core.agent.Router Router} classes, and routing them to the correct
+ * destination. The class implements {@link weiss.core.agent.MetaAgent MetaAgent},
  * which is the basis for all of our MAS classes.
  * <p>
  * When the object receives a message, it checks it's own
  * {@link Portal#routingTable Routing Table} for the value found in the
  * {@link weiss.Message.Message#to To} field. If the object is found, it passes
  * the message on to the selected object. If not, the object is passed to its
- * assigned {@link weiss.MetaAgent.Router Router}.
+ * assigned {@link weiss.core.agent.Router Router}.
  *
  *
  * @author Adam Young, Teesside University Sch. of Computing

--- a/src/weiss/core/agent/Router.java
+++ b/src/weiss/core/agent/Router.java
@@ -14,13 +14,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package weiss.MetaAgent;
+package weiss.core.agent;
 
-import weiss.Message.RouterMessage;
-import weiss.Message.*;
+import weiss.core.message.Message;
+import weiss.core.message.UserMessage;
+import weiss.core.message.DecoratedMessage;
+import weiss.core.message.ReplyMessage;
+import weiss.core.message.SysMessage;
+import weiss.core.message.RouterMessage;
 
 /**
- * * Class used for handling messages from {@link weiss.MetaAgent.Portal Portal}
+ * * Class used for handling messages from {@link weiss.core.agent.Portal Portal}
  * classes, and routing them to the correct destination. Routers are linked
  * together in a pseudo linked list.
  * <p>

--- a/src/weiss/core/agent/WeissBase.java
+++ b/src/weiss/core/agent/WeissBase.java
@@ -14,15 +14,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package weiss.MetaAgent;
+package weiss.core.agent;
 
-import Weiss.Manager.NodeMonitor;
+import weiss.manager.NodeMonitor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import weiss.Message.Message;
-import weiss.Message.SysMessage;
-import weiss.Message.UserMessage;
+import weiss.core.message.Message;
+import weiss.core.message.SysMessage;
+import weiss.core.message.UserMessage;
 
 /**
  *

--- a/src/weiss/core/message/DecoratedMessage.java
+++ b/src/weiss/core/message/DecoratedMessage.java
@@ -1,4 +1,4 @@
-package weiss.Message;
+package weiss.core.message;
 
 /**
  * @author Scott Taylor, Teesside University Sch. of Computing

--- a/src/weiss/core/message/Message.java
+++ b/src/weiss/core/message/Message.java
@@ -1,4 +1,4 @@
-package weiss.Message;
+package weiss.core.message;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;

--- a/src/weiss/core/message/ReplyMessage.java
+++ b/src/weiss/core/message/ReplyMessage.java
@@ -1,4 +1,4 @@
-package weiss.Message;
+package weiss.core.message;
 
 /**
  * @author Scott Taylor, Teesside University Sch. of Computing

--- a/src/weiss/core/message/RouterMessage.java
+++ b/src/weiss/core/message/RouterMessage.java
@@ -3,7 +3,7 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package weiss.Message;
+package weiss.core.message;
 
 /**
  *

--- a/src/weiss/core/message/SysMessage.java
+++ b/src/weiss/core/message/SysMessage.java
@@ -3,9 +3,9 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package weiss.Message;
+package weiss.core.message;
 
-import weiss.MetaAgent.MetaAgent;
+import weiss.core.agent.MetaAgent;
 
 /** Class extending the {@link Message Message} class, to be used for system message transmission.
  * This type of message can be read by all MetaAgents, and contains instructions rather than text.

--- a/src/weiss/core/message/UserMessage.java
+++ b/src/weiss/core/message/UserMessage.java
@@ -3,7 +3,7 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package weiss.Message;
+package weiss.core.message;
 
 import java.util.UUID;
 


### PR DESCRIPTION
put agent and message packages within the weiss.core package, so if a
client doesn't want to use the manager but still wants to use the
backend, they can